### PR TITLE
Add function declaration to spi_sr.h

### DIFF
--- a/libraries/grbl_644/spi_sr.h
+++ b/libraries/grbl_644/spi_sr.h
@@ -25,6 +25,9 @@ uint8_t sr_outputs_unused, sr_inputs_unused;										// SPI Display
 	// schiebt 16 Bit aus sr_outpus_0/_1 in Hardware-SR
 	// und holt 16 Bit aus Hardware-SRs in sr_inputs_0/_1
 	void spi_txrx_inout();
+
+	// TODO: document function. being used in spi_sr.c and jogpad.c
+	void spi_tx_axis(uint8_t axis_idx);
 	
 	// Achsenpositionen senden
 	void spi_tx_axis_roundrobin();


### PR DESCRIPTION
See https://github.com/heise/MaXYposi_Grbl_644/pull/10 too. "spi_tx_axis" is being used in jogpad.c too and should thus be declared here.